### PR TITLE
Fixed build errors due to changes in dependencies.

### DIFF
--- a/GPX.cabal
+++ b/GPX.cabal
@@ -1,5 +1,5 @@
 Name:                GPX
-Version:             0.7.0
+Version:             0.7.1
 License:             BSD3
 License-File:        LICENSE
 Synopsis:            Parse GPX files
@@ -24,8 +24,9 @@ Library
                      , hxt >= 9
                      , containers
                      , comonad-transformers
+                     , comonad >= 4.0
                      , data-lens
-                     , xsd
+                     , xsd >= 0.3 && < 0.4
                      , newtype
 
   GHC-Options:      -Wall


### PR DESCRIPTION
Things have changed on Hackage in the past 9 months, and now GPX won't build anymore. This patch fixes things; two important changes really: comonad is now an explicit dependency, and the XSD dependency is fixed at a version that uses String rather than Text.

BTW., this fixes the issue I just reported (#2 if I'm no mistaken).
